### PR TITLE
Remove server address from configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,5 +9,5 @@ RUN go build -o /golim ./cli/main.go
 FROM alpine
 WORKDIR /
 COPY --from=build /golim /golim
-EXPOSE 8080
+EXPOSE 80
 ENTRYPOINT [ "/golim" ]

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Rate-limited proxy server in Go. This can be used in two ways
 
 ## Pull from DockerHub
 
-The easiest way to use this is via the docker hub image.
+The easiest way to use this is via the docker hub image. To start running golim on port 8080:
 
 ```sh
 docker run --rm -p 8080:80 shubham1172/golim:latest -web-server-addr=http://192.168.0.12:8000

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Rate-limited proxy server in Go. This can be used in two ways
 The easiest way to use this is via the docker hub image.
 
 ```sh
-docker run --rm -p 8080:8080 shubham1172/golim:latest -web-server-addr=http://192.168.0.12:8000
+docker run --rm -p 8080:80 shubham1172/golim:latest -web-server-addr=http://192.168.0.12:8000
 ```
 
 ## Build from source
@@ -32,7 +32,6 @@ Golim can be configured via the command line arguments or the environment variab
 | Command Line Argument | Environment Variable | Description |
 |-|-|-|
 | -web-server-addr | GOLIM_WEB_SERVER_ADDR | Address of the web server. |
-| -server-addr | GOLIM_SERVER_ADDR | Address of the golim server.  |
 | -rate-limiter-burst | GOLIM_RATE_LIMITER_BURST | Number of requests that can be made in a given time window. |
 | -rate-limiter-window-seconds | GOLIM_RATE_LIMITER_WINDOW_SECONDS | Time window in seconds for which the burst is allowed. |
 

--- a/cli/main.go
+++ b/cli/main.go
@@ -16,10 +16,11 @@ import (
 
 var (
 	webServerAddr            = "http://127.0.0.1:8000"
-	serverAddress            = "0.0.0.0:8080"
 	rateLimiterBurst         = 20
 	rateLimiterWindowSeconds = 1
 )
+
+const serverAddress = "0.0.0.0:80"
 
 func getProxyHandler(target *url.URL) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
@@ -51,7 +52,6 @@ func main() {
 	logger := log.New(os.Stdout, "", log.LstdFlags)
 
 	// set up flags
-	flag.StringVar(&serverAddress, "server-addr", lookupEnvOrDefaultString("GOLIM_SERVER_ADDR", serverAddress), "address of this server")
 	flag.StringVar(&webServerAddr, "web-server-addr", lookupEnvOrDefaultString("GOLIM_WEB_SERVER_ADDR", webServerAddr), "address of the web server")
 	flag.IntVar(&rateLimiterBurst, "rate-limiter-burst", lookupEnvOrDefaultInt("GOLIM_RATE_LIMITER_BURST", rateLimiterBurst), "number of requests that can be made in a given time window")
 	flag.IntVar(&rateLimiterWindowSeconds, "rate-limiter-window-seconds", lookupEnvOrDefaultInt("GOLIM_RATE_LIMITER_WINDOW_SECONDS", rateLimiterWindowSeconds), "time window in seconds for which the burst is allowed")
@@ -72,7 +72,7 @@ func main() {
 	middlewareMux = middleware.NewRequestIDMiddleware(middlewareMux)
 
 	// start the server
-	logger.Printf("Starting the server on %s\n", serverAddress)
+	logger.Printf("Starting the server on %s (container)\n", serverAddress)
 
 	err = http.ListenAndServe(serverAddress, middlewareMux)
 	if err != nil {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,9 +7,8 @@ services:
     image: shubham1172/golim:latest
     container_name: golim
     environment:
-      - GOLIM_WEB_SERVER_ADDR=http://192.168.0.12:8000
-      - GOLIM_SERVER_ADDR=0.0.0.0:8080
+      - GOLIM_WEB_SERVER_ADDR=http://192.168.0.11:8000
       - GOLIM_RATE_LIMITER_BURST=20
       - GOLIM_RATE_LIMITER_WINDOW_SECONDS=1
     ports:
-      - "8080:8080"
+      - "8080:80"


### PR DESCRIPTION
Since golim is containerized, there is no need to configure the golim server's address. Port mapping can be done using docker command line with `-p` flag or docker-compose.